### PR TITLE
SNS認証を実現するためのメソッドを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,5 @@ gem 'omniauth-facebook'
 gem 'omniauth-google-oauth2'
 # CSRF脆弱性を対策するため
 gem "omniauth-rails_csrf_protection"
+
+gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     devise (4.7.3)
@@ -145,6 +146,11 @@ GEM
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.6)
     puma (3.12.6)
     rack (2.2.3)
@@ -273,6 +279,7 @@ DEPENDENCIES
   omniauth-facebook
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
+  pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
   rubocop

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,30 +1,20 @@
-# frozen_string_literal: true
-
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+  def facebook
+    authorization
+  end
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+  def google_oauth2
+    authorization
+  end
 
-  # More info at:
-  # https://github.com/heartcombo/devise#omniauth
+  private
 
-  # GET|POST /resource/auth/twitter
-  # def passthru
-  #   super
-  # end
-
-  # GET|POST /users/auth/twitter/callback
-  # def failure
-  #   super
-  # end
-
-  # protected
-
-  # The path used when OmniAuth fails
-  # def after_omniauth_failure_path_for(scope)
-  #   super(scope)
-  # end
+  def authorization
+    @user = User.from_omniauth(request.env['omniauth.auth'])
+    if @user.persisted? # ユーザー情報が登録済みなので、新規登録ではなくログイン処理を行う
+      sign_in_and_redirect @user, event: :authentication
+    else # ユーザー情報が未登録なので、新規登録画面へ遷移する
+      render template: 'devise/registrations/new'
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,16 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
   has_many :sns_credentials
+
+  # omniauth_callbacks_controller.rbに記述した、User.from_omniauthを呼び出し
+  def self.from_omniauth(auth)
+    # 保存するレコードがDBに存在するか検索を行い、検索した条件のレコードがあればそのレコードを返し、なければインスタンスを保存するメソッド（保存時にUserモデルとSnsCredentialモデルを紐付け）
+    sns = SnsCredential.where(provider: auth.provider, uid: auth.uid).first_or_create
+    # sns認証したことがあればアソシエーションで取得
+    # 無ければemailでユーザー検索して取得orビルド(保存はしない)
+    user = User.where(email: auth.info.email).first_or_initialize(
+      nickname: auth.info.name,
+      email: auth.info.email
+    )
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,5 +14,12 @@ class User < ApplicationRecord
       nickname: auth.info.name,
       email: auth.info.email
     )
+    # userが登録済みであるか判断
+    if user.persisted?
+    # ログインの際に、sns.userを更新して紐付けを行う
+      sns.user = user
+      sns.save
+    end
+    user
   end
 end

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,5 +1,8 @@
 <h2>Log in</h2>
 
+<%= link_to 'Facebookでログイン', user_facebook_omniauth_authorize_path, method: :post%>
+<%= link_to 'Googleでログイン', user_google_oauth2_omniauth_authorize_path, method: :post%>
+
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
     <%= f.label :email %><br />

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,1 +1,4 @@
 <%= link_to "メールアドレスで登録", new_user_registration_path%>
+
+<%= link_to 'Facebookで登録', user_facebook_omniauth_authorize_path, method: :post%>
+<%= link_to 'Googleで登録', user_google_oauth2_omniauth_authorize_path, method: :post%>


### PR DESCRIPTION
Closes #4  

# What
- ①Facebook（またはGoogle）での認証が開始
- ②Facebook（またはGoogle）側にリクエストが送られる
- ③認証を経て、コントローラーにSNSに登録されている情報が返される
- ④SNSの情報から、ユーザー情報のみを取得して、既存のユーザー情報と照合を行う
- ⑤その照合結果から、今回SNSで認証されたユーザーが、すでにアプリケーションに登録されているユーザーなのか判断する
- ⑥照合の結果、既存のユーザーが存在しない場合は、新規登録画面に遷移する
- ⑦すでに同じ情報のユーザーがアプリケーションのDBに存在している場合は、ログイン処理を行う
- 上記①〜⑦について、OmniAuthのメソッド用いて実装していく。

# Why
- 外部APIを使用する際のメソッドに則って実装するため。